### PR TITLE
Remove Rocket.Chat from GSoC iOS Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Example-iOS-Apps is an amazing list for people who are beginners and learning iO
 - Go through our *Content Menu*
 
 ## iOS Apps that Take Part in Google Summer of Code
-* [Rocket.Chat.iOS](https://github.com/imjog/Rocket.Chat.iOS) - Rocket.Chat Native iOS Application.
 * [SUSI iOS](https://github.com/fossasia/susi_iOS) - SUSI AI iOS app by FOSSASIA.
 * [Open Event Orga iOS](https://github.com/fossasia/open-event-orga-iOS) - Event management app for organizers using Open Event Platform by FOSSASIA
 * [Open Event iOS](https://github.com/fossasia/open-event-ios) - Open Event iOS app by FOSSASIA.


### PR DESCRIPTION
Rocket.Chat moved to react native.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `example-ios-apps` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Only one project/change is in this pull request
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 3 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
